### PR TITLE
Add support for the GenericIO.readlnString and readlnIn goofiness

### DIFF
--- a/unborges
+++ b/unborges
@@ -3,3 +3,5 @@
 sed -i '/import genclass.GenericIO;/d' $1
 sed -i 's/GenericIO.writeString/System.out.print/g' $1
 sed -i 's/GenericIO.writelnString/System.out.println/g' $1
+sed -i 's/GenericIO.readlnString *()/System.console().readLine()/g' $1
+sed -i 's/GenericIO.readlnInt *()/Integer.parseInt(System.console().readLine())/g' $1


### PR DESCRIPTION
Not sure if System.console()  is the better approach since it won't work on an IDE, but it's my current solution